### PR TITLE
Added aws-setup-and-wait.sh deploy script

### DIFF
--- a/scripts/utils/aws-setup-and-wait.sh
+++ b/scripts/utils/aws-setup-and-wait.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#   Use this script to setup the build environment with Elasticsearch's certificates.
+#   This scripts expects:
+#      * ES_CERTIFICATE env variable: it contains a base64-encoded PKCS12 certificate
+#      * the /starchat folder to be present and writable
+
+if [ -n "$ES_CERTIFICATE" ]; then
+  echo -n "$ES_CERTIFICATE" | base64 -D > /starchat/es.p12
+fi
+
+"$(dirname $0)"/wait-for-it.sh "$@"


### PR DESCRIPTION
Added a new utility script for setting up Elasticsearch certificates without  importing files in a Docker container.