### PR TITLE
GJ-1554 keyword and UCT

### DIFF
--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/KeywordAtomic2.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/KeywordAtomic2.scala
@@ -32,7 +32,7 @@ class KeywordAtomic2(arguments: List[String], restrictedArgs: Map[String, String
   }
 
   // regular expression used to understand if the user query contains the keyword/regex specified in the atom argument
-  private[this] val rxToBeMatched: Regex = {"""(?ui)\b""" + atomArgument.replace("*", """\w*""") + """\b"""}.r
+  private[this] val rxToBeMatched: Regex = {"""(?ui)\b""" + atomArgument.replace("*", """[\p{L}\p{N}]*""") + """\b"""}.r
 
   override def toString: String = atomName + "(\"" + atomArgument + "\")"
 

--- a/src/test/scala/com/getjenny/starchat/resources/AnalyzersPlaygroundResourceTest.scala
+++ b/src/test/scala/com/getjenny/starchat/resources/AnalyzersPlaygroundResourceTest.scala
@@ -64,6 +64,52 @@ class AnalyzersPlaygroundResourceTest extends TestEnglishBase {
   }
 
   it should {
+    "return an HTTP code 200 when evaluating a single keyword analyzer with unicode query using matches" in {
+      val evaluateRequest: AnalyzerEvaluateRequest =
+        AnalyzerEvaluateRequest(
+          query = "hello helsingiss3ä!",
+          analyzer = """and(max(bor(keyword("helsin*"))))""",
+          data = Option {
+            AnalyzersData()
+          }
+        )
+
+      Post(s"/index_getjenny_english_0/analyzer/playground", evaluateRequest) ~> addCredentials(testUserCredentials) ~> routes ~> check {
+        status shouldEqual StatusCodes.OK
+        val response = responseAs[AnalyzerEvaluateResponse]
+        response.build should be(true)
+        response.buildMessage should be("success")
+        response.value should be(1.0)
+      }
+    }
+
+  }
+
+  it should {
+    "return an HTTP code 200 when evaluating a pair keyword analyzer with unicode query using matches" in {
+      val evaluateRequest: AnalyzerEvaluateRequest =
+        AnalyzerEvaluateRequest(
+          query = "kivassödfks koirasdölfksdöl",
+          analyzer = """and(max(bor(keyword("kiva* koira*"))))""",
+          data = Option {
+            AnalyzersData()
+          }
+        )
+
+      Post(s"/index_getjenny_english_0/analyzer/playground", evaluateRequest) ~> addCredentials(testUserCredentials) ~> routes ~> check {
+        status shouldEqual StatusCodes.OK
+        val response = responseAs[AnalyzerEvaluateResponse]
+        response.build should be(true)
+        response.buildMessage should be("success")
+        response.value should be(1.0)
+      }
+    }
+
+  }
+
+
+
+  it should {
     "return an HTTP code 200 when checking if a value exists in the traversed states list" in {
       val evaluateRequest: AnalyzerEvaluateRequest =
         AnalyzerEvaluateRequest(


### PR DESCRIPTION
Keyword pattern matching was not handly correctly unicode characters.
The issues was introduce when we added the \w  command to separate word.
\w means ascii letters and numbers.
\w was changed with [\p{L}\p{N}]