### PR TITLE
Uncomment test on parseDate atom and fix documentation

### DIFF
--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/ParseDateVariableManager.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/ParseDateVariableManager.scala
@@ -10,7 +10,7 @@ import java.util.Calendar
 import DefaultJsonProtocol._
 
 /**
-  * parseDate("language=it,timezone=US/Eastern")
+  * parseDate("language=it", "timezone=US/Eastern")
   * output:
   * "extracted_date.score" 0 if no date is found
   * "extracted_date.status"

--- a/src/test/scala/com/getjenny/starchat/analyzer/atoms/http/HttpRequestAtomicTest.scala
+++ b/src/test/scala/com/getjenny/starchat/analyzer/atoms/http/HttpRequestAtomicTest.scala
@@ -383,17 +383,17 @@ class HttpRequestAtomicTest extends WordSpec with Matchers with ScalatestRouteTe
       configuration.map(println)
     }
 
-    //TODO: these test can be enabled when the parameters are moved to a secret travis variable
-    /*
-    "crate a valid date parser atom configuration " in {
+    "create a valid date parser atom configuration " in {
       val variableManager = new ParseDateVariableManager {}
       val systemConf = SystemConfiguration
         .createMapFromPath("starchat.atom-values")
 
-      val configuration = variableManager.validateAndBuild(List.empty, systemConf, Map.empty, "July 22nd, 1947")
+      val configuration = variableManager.validateAndBuild(List("language=en","timezone=GMT+1"), systemConf, Map.empty, "July 22nd, 1947")
       configuration shouldBe a [Success[_]]
       configuration.map(println)
     }
+    //TODO: these test can be enabled when the parameters are moved to a secret travis variable
+    /*
 
     "create a valid read s3 atom configuration" in {
       val variableManager = new ReadS3DataVariableManager {}

--- a/src/test/scala/com/getjenny/starchat/analyzer/atoms/http/HttpRequestAtomicTest.scala
+++ b/src/test/scala/com/getjenny/starchat/analyzer/atoms/http/HttpRequestAtomicTest.scala
@@ -383,6 +383,8 @@ class HttpRequestAtomicTest extends WordSpec with Matchers with ScalatestRouteTe
       configuration.map(println)
     }
 
+    //TODO: these test can be enabled when the parameters are moved to a secret travis variable
+    /*
     "create a valid date parser atom configuration " in {
       val variableManager = new ParseDateVariableManager {}
       val systemConf = SystemConfiguration
@@ -392,8 +394,6 @@ class HttpRequestAtomicTest extends WordSpec with Matchers with ScalatestRouteTe
       configuration shouldBe a [Success[_]]
       configuration.map(println)
     }
-    //TODO: these test can be enabled when the parameters are moved to a secret travis variable
-    /*
 
     "create a valid read s3 atom configuration" in {
       val variableManager = new ReadS3DataVariableManager {}


### PR DESCRIPTION
For some reason, the test "create a valid date parser atom configuration " wasn't active on master. I modified it according to the last changes to parseDate and uncommented the test.