### PR TITLE
GJ-1474 Keyword analyzer in configurator 3.0

### DIFF
--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/KeywordAtomic2.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/KeywordAtomic2.scala
@@ -32,7 +32,7 @@ class KeywordAtomic2(arguments: List[String], restrictedArgs: Map[String, String
   }
 
   // regular expression used to understand if the user query contains the keyword/regex specified in the atom argument
-  private[this] val rxToBeMatched: Regex = {"""(?ui)\b""" + atomArgument.replace("*", """[\p{L}\p{N}]*""") + """\b"""}.r
+  private[this] val rxToBeMatched: Regex = {"""(?ui)\b""" + atomArgument.replace("*", """[\p{L}\p{N}.\-_@\~]*""") + """\b"""}.r
 
   override def toString: String = atomName + "(\"" + atomArgument + "\")"
 

--- a/src/test/scala/com/getjenny/starchat/resources/AnalyzersPlaygroundResourceTest.scala
+++ b/src/test/scala/com/getjenny/starchat/resources/AnalyzersPlaygroundResourceTest.scala
@@ -139,6 +139,28 @@ class AnalyzersPlaygroundResourceTest extends TestEnglishBase {
 
   }
 
+  it should {
+    """match when keyyword("suomi*fi") is tested with query suomi@ac~something-strange_my.fi """ in {
+      val evaluateRequest: AnalyzerEvaluateRequest =
+        AnalyzerEvaluateRequest(
+          query = "suomi@ac~something-strange_my.fi",
+          analyzer = """and(max(bor(keyword("suomi*fi"))))""",
+          data = Option {
+            AnalyzersData()
+          }
+        )
+
+      Post(s"/index_getjenny_english_0/analyzer/playground", evaluateRequest) ~> addCredentials(testUserCredentials) ~> routes ~> check {
+        status shouldEqual StatusCodes.OK
+        val response = responseAs[AnalyzerEvaluateResponse]
+        response.build should be(true)
+        response.buildMessage should be("success")
+        response.value should be(1.0)
+      }
+    }
+
+  }
+
 
 
   it should {


### PR DESCRIPTION
The new keyword analyzer to handle double word replaces * with [\p{L}\p{N}]*
This regex does not include dot character that sometimes is used inside
a "concatenated" word like internet/email addresses.
To fix this issue '.' '-' '_' '@' "~" were added to the list of characters
allowed inside a "single" word.