### PR TITLE
GJ-1926 parseDate atom improvement - multiple dates in output

### DIFF
--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/ParseDateVariableManager.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/ParseDateVariableManager.scala
@@ -59,26 +59,47 @@ case class ParseDateOutput(
         case _ => Array.empty[String]
       }.getOrElse(Array.empty[String])
 
-      val s = if(dateList.isEmpty) "0" else "1"
+      if(dateList.isEmpty) {
+        Map(
+          score -> "0",
+          responseStatus -> status.toString
+        )
+      } else {
 
-      val dateIso = dateList.headOption.getOrElse("")
-      val format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
-      val dateObj = if (dateIso.isEmpty) format.parse("1970-01-01T00:00:00") else format.parse(dateIso)
-      val cal = Calendar.getInstance()
-      cal.setTime(dateObj)
+        val format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
 
-      Map(
-        date -> dateIso,
-        year -> "%04d".format(cal.get(Calendar.YEAR)),
-        month -> "%02d".format(cal.get(Calendar.MONTH) + 1),
-        dayOfMonth -> "%02d".format(cal.get(Calendar.DAY_OF_MONTH)),
-        dayOfWeek -> "%01d".format(cal.get(Calendar.DAY_OF_WEEK) - 1 match {case 0 => 7; case n => n}),
-        hour -> "%02d".format(cal.get(Calendar.HOUR_OF_DAY)),
-        minute -> "%02d".format(cal.get(Calendar.MINUTE)),
-        second -> "%02d".format(cal.get(Calendar.SECOND)),
-        score -> s,
-        responseStatus -> status.toString
-      )
+        def dateToMap(dateIso: String) = {
+          val dateObj = format.parse(dateIso)
+          val cal = Calendar.getInstance()
+          cal.setTime(dateObj)
+          Map(
+            date -> dateIso,
+            year -> "%04d".format(cal.get(Calendar.YEAR)),
+            month -> "%02d".format(cal.get(Calendar.MONTH) + 1),
+            dayOfMonth -> "%02d".format(cal.get(Calendar.DAY_OF_MONTH)),
+            dayOfWeek -> "%01d".format(cal.get(Calendar.DAY_OF_WEEK) - 1 match {case 0 => 7; case n => n}),
+            hour -> "%02d".format(cal.get(Calendar.HOUR_OF_DAY)),
+            minute -> "%02d".format(cal.get(Calendar.MINUTE)),
+            second -> "%02d".format(cal.get(Calendar.SECOND))
+          )
+        }
+
+        def appendMapIndex(dateMap: Map[String, String], i: Int) = {
+          i match {
+            case 0 => dateMap
+            case _ => dateMap.map { case(key, value) => key + "." + i -> value}
+          }
+        }
+
+        val dateMapList = dateList.map(x => dateToMap(x))
+        val dateOutList = (dateMapList.indices zip dateMapList).map { case (i, d) => appendMapIndex(d, i) }
+
+        (dateOutList reduce (_ ++ _)) ++
+          Map(
+            score -> "1",
+            responseStatus -> status.toString
+          )
+      }
     } else {
       Map(
         score -> "0",

--- a/src/test/scala/com/getjenny/starchat/analyzer/atoms/http/HttpRequestAtomicTest.scala
+++ b/src/test/scala/com/getjenny/starchat/analyzer/atoms/http/HttpRequestAtomicTest.scala
@@ -428,7 +428,6 @@ class HttpRequestAtomicTest extends AnyWordSpec with Matchers with ScalatestRout
 
       val analyzerData = Map(
         "language" -> "it",
-        //"timezone" -> "US/Eastern"
         "timezone" -> "GMT+3"
       )
 
@@ -437,9 +436,58 @@ class HttpRequestAtomicTest extends AnyWordSpec with Matchers with ScalatestRout
 
       val atom = new HttpRequestAtomic(List(), systemConf) with ParseDateVariableManager
 
-      val result = atom.evaluate("domani", AnalyzersDataInternal(extractedVariables = analyzerData))
-      println(result)
+      val result = atom.evaluate("24 Marzo 1985, 4 Aprile 2014, 2 Giugno 1989", AnalyzersDataInternal(extractedVariables = analyzerData))
 
+      result.data.extractedVariables.foreach(println)
+      result.data.extractedVariables.getOrElse("extracted_date.score", "") shouldBe "1"
+      result.data.extractedVariables.getOrElse("extracted_date.status", "") shouldBe "200 OK"
+
+      // 24th of March 1985
+      result.data.extractedVariables.getOrElse("extracted_date.date_iso", "") shouldBe "1985-03-24T00:00:00"
+      result.data.extractedVariables.getOrElse("extracted_date.year", "") shouldBe "1985"
+      result.data.extractedVariables.getOrElse("extracted_date.month", "") shouldBe "03"
+      result.data.extractedVariables.getOrElse("extracted_date.day_of_month", "") shouldBe "24"
+      result.data.extractedVariables.getOrElse("extracted_date.day_of_week", "") shouldBe "7"
+      result.data.extractedVariables.getOrElse("extracted_date.hour", "") shouldBe "00"
+      result.data.extractedVariables.getOrElse("extracted_date.minute", "") shouldBe "00"
+      result.data.extractedVariables.getOrElse("extracted_date.second", "") shouldBe "00"
+      // 4th of April 2014
+      result.data.extractedVariables.getOrElse("extracted_date.date_iso.1", "") shouldBe "2014-04-04T00:00:00"
+      result.data.extractedVariables.getOrElse("extracted_date.year.1", "") shouldBe "2014"
+      result.data.extractedVariables.getOrElse("extracted_date.month.1", "") shouldBe "04"
+      result.data.extractedVariables.getOrElse("extracted_date.day_of_month.1", "") shouldBe "04"
+      result.data.extractedVariables.getOrElse("extracted_date.day_of_week.1", "") shouldBe "5"
+      result.data.extractedVariables.getOrElse("extracted_date.hour.1", "") shouldBe "00"
+      result.data.extractedVariables.getOrElse("extracted_date.minute.1", "") shouldBe "00"
+      result.data.extractedVariables.getOrElse("extracted_date.second.1", "") shouldBe "00"
+      // 2nd of June 1989
+      result.data.extractedVariables.getOrElse("extracted_date.date_iso.2", "") shouldBe "1989-06-02T00:00:00"
+      result.data.extractedVariables.getOrElse("extracted_date.year.2", "") shouldBe "1989"
+      result.data.extractedVariables.getOrElse("extracted_date.month.2", "") shouldBe "06"
+      result.data.extractedVariables.getOrElse("extracted_date.day_of_month.2", "") shouldBe "02"
+      result.data.extractedVariables.getOrElse("extracted_date.day_of_week.2", "") shouldBe "5"
+      result.data.extractedVariables.getOrElse("extracted_date.hour.2", "") shouldBe "00"
+      result.data.extractedVariables.getOrElse("extracted_date.minute.2", "") shouldBe "00"
+      result.data.extractedVariables.getOrElse("extracted_date.second.2", "") shouldBe "00"
+    }
+
+    "test dateParser without date" in {
+
+      val analyzerData = Map(
+        "language" -> "en",
+        "timezone" -> "GMT+3"
+      )
+
+      val systemConf = SystemConfiguration
+        .createMapFromPath("starchat.atom-values")
+
+      val atom = new HttpRequestAtomic(List(), systemConf) with ParseDateVariableManager
+
+      val result = atom.evaluate("asdasd", AnalyzersDataInternal(extractedVariables = analyzerData))
+
+      result.data.extractedVariables.foreach(println)
+      result.data.extractedVariables.getOrElse("extracted_date.score", "") shouldBe "0"
+      result.data.extractedVariables.getOrElse("extracted_date.status", "") shouldBe "200 OK"
     }*/
 
     /*


### PR DESCRIPTION
Now the atom parseDate returns all the dates recognised by the http service. If a single date is detected, the output is the same as before. If more than one date is detected in the query, for each additional date an index is appended to the keys of the output map. E.g.
```
Map(
    "extracted_date.score" -> "1",
    "extracted_date.status" -> "200 OK",
    "extracted_date.date_iso" -> "1985-03-24T00:00:00",
    "extracted_date.year" -> "1985",
    ...
    "extracted_date.date_iso.1" -> "2020-06-23T00:00:00",
    "extracted_date.year.1" -> "2020",
    ...
    "extracted_date.date_iso.2" -> "2012-11-03T00:00:00",
    "extracted_date.year.2" -> "2012",
    ...
)
```