### PR TITLE
Replace spaces in url strings by plus symbol in http atom config

### DIFF
--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/GenericVariableManager.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/GenericVariableManager.scala
@@ -47,7 +47,7 @@ trait GenericVariableManager extends VariableManager {
   }
 
   def authenticationConf(configMap: VariableConfiguration, findProperty: String => Option[String]): AtomValidation[Option[HttpAtomAuthConf]] = {
-    if (configMap.get(authorizationType).nonEmpty) {
+    if (configMap.contains(authorizationType)) {
       as[AuthorizationType](authorizationType).run(configMap) match {
         case Success(AuthorizationType.BASIC) =>
           (as[String](username) |@| as[String](password)) ((u, p) => (u |@| p) (BasicAuth))
@@ -71,8 +71,8 @@ trait GenericVariableManager extends VariableManager {
   }
 
   def inputConf(configMap: VariableConfiguration, findProperty: String => Option[String]): AtomValidation[Option[HttpAtomInputConf]] = {
-    val isQueryString = configMap.get(inputQueryTemplate).nonEmpty
-    val isJson = configMap.get(inputJson).nonEmpty
+    val isQueryString = configMap.contains(inputQueryTemplate)
+    val isJson = configMap.contains(inputJson)
     (isQueryString, isJson) match {
       case (true, true) => Failure(NonEmptyList("Both json and query string configuration enabled"))
       case (true, false) => extractInput[QueryStringConf](inputQueryTemplate,

--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/GenericVariableManager.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/GenericVariableManager.scala
@@ -10,7 +10,7 @@ import scalaz.Validation.FlatMap._
 import scalaz.{Failure, NonEmptyList, Success}
 
 /**
-  * Generic class to get hettp-atom-conf configuration parameters.
+  * Generic class to get http-atom-conf configuration parameters.
   *
   * To create a new atomic, typically:
   *
@@ -78,7 +78,7 @@ trait GenericVariableManager extends VariableManager {
       case (true, false) => extractInput[QueryStringConf](inputQueryTemplate,
         configMap,
         findProperty) {
-        QueryStringConf
+        x => QueryStringConf(x.replace(" ", "+"))
       }.map(_.some)
       case (false, true) =>
         extractInput[JsonConf](inputJson,

--- a/src/test/scala/com/getjenny/starchat/analyzer/atoms/http/HttpRequestAtomicTest.scala
+++ b/src/test/scala/com/getjenny/starchat/analyzer/atoms/http/HttpRequestAtomicTest.scala
@@ -1,6 +1,7 @@
 package com.getjenny.starchat.analyzer.atoms.http
 
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.getjenny.analyzer.expressions.AnalyzersDataInternal
 import com.getjenny.starchat.analyzer.atoms.http.custom.WeatherVariableManager
 import com.getjenny.starchat.utils.SystemConfiguration
 import org.scalatest.matchers.should.Matchers
@@ -338,6 +339,27 @@ class HttpRequestAtomicTest extends AnyWordSpec with Matchers with ScalatestRout
       validation shouldBe a[Success[_]]
     }
 
+    "create a valid http atom configuration with spaces in input-query-template" in {
+      val systemConf = SystemConfiguration
+        .createMapFromPath("starchat.atom-values")
+      val arguments = List("http-atom.test.url=www.google.it",
+        "http-atom.test.http-method=GET",
+        "http-atom.test.input-query-template",
+        "http-atom.test.output-content-type=test.content-type",
+        "http-atom.test.output-status=test.status",
+        "http-atom.test.output-data=test.data",
+        "http-atom.test.output-score=test.score"
+      )
+      val analyzerData = Map("http-atom.test.input-query-template" -> "aaa=b cd e")
+      val configuration = variableManager.validateAndBuild(arguments,systemConf, analyzerData, "")
+
+      configuration shouldBe a[Success[_]]
+      configuration.foreach { conf =>
+        val queryString = conf.inputConf.collect { case QueryStringConf(queryString) => queryString }.getOrElse("")
+        queryString shouldEqual "aaa=b+cd+e"
+      }
+    }
+
     /*"test weather api call and do not execute call if done before and actual call is 0" in {
       val description = "desc"
       val humidity = "1"
@@ -378,6 +400,30 @@ class HttpRequestAtomicTest extends AnyWordSpec with Matchers with ScalatestRout
 
     //TODO: these test can be enabled when the parameters are moved to a secret travis variable
     /*
+    "test weather api call" in {
+      val analyzerData = Map(
+        "location" -> "Torino,IT"
+      )
+      val systemConf = SystemConfiguration.createMapFromPath("starchat.atom-values")
+      val atom = new HttpRequestAtomic(List.empty, systemConf) with WeatherVariableManager
+      val result = atom.evaluate("", AnalyzersDataInternal(extractedVariables = analyzerData))
+      result.data.extractedVariables.foreach(println)
+      result.data.extractedVariables.getOrElse("weather.score", "") shouldBe "1"
+      result.data.extractedVariables.getOrElse("weather.status", "") shouldBe "200 OK"
+    }
+
+    "test weather api call with multi-token location" in {
+      val analyzerData = Map(
+        "location" -> "New York"
+      )
+      val systemConf = SystemConfiguration.createMapFromPath("starchat.atom-values")
+      val atom = new HttpRequestAtomic(List.empty, systemConf) with WeatherVariableManager
+      val result = atom.evaluate("", AnalyzersDataInternal(extractedVariables = analyzerData))
+      result.data.extractedVariables.foreach(println)
+      result.data.extractedVariables.getOrElse("weather.score", "") shouldBe "1"
+      result.data.extractedVariables.getOrElse("weather.status", "") shouldBe "200 OK"
+    }
+
     "create a valid date parser atom configuration " in {
       val variableManager = new ParseDateVariableManager {}
       val systemConf = SystemConfiguration


### PR DESCRIPTION
Now it is possible to use url parameters with spaces.

For example `weather("location=New York")` passes the location parameter as `New+York` in the url.