### PR TITLE
Deal with spaces and non-ascii characters in http atom url

### DIFF
--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/GenericVariableManager.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/GenericVariableManager.scala
@@ -78,7 +78,7 @@ trait GenericVariableManager extends VariableManager {
       case (true, false) => extractInput[QueryStringConf](inputQueryTemplate,
         configMap,
         findProperty) {
-        x => QueryStringConf(x.replace(" ", "+"))
+        QueryStringConf
       }.map(_.some)
       case (false, true) =>
         extractInput[JsonConf](inputJson,

--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/HttpRequestAtomic.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/HttpRequestAtomic.scala
@@ -93,26 +93,26 @@ class HttpRequestAtomic(arguments: List[String], restrictedArgs: Map[String, Str
         Nil -> s"$key=$token".some
       case _ => Nil -> None
     }
-    val urlClean = cleanUrl(configuration.urlConf.url)
-    val urlAuth = authQueryParam.map(auth => s"$urlClean?$auth").getOrElse(urlClean)
+
+    val url = authQueryParam.map(auth => s"${configuration.urlConf.url}?$auth").getOrElse(configuration.urlConf.url)
 
     val (finalUrl, httpBody) = configuration.inputConf match {
       case Some(QueryStringConf(queryString)) =>
         if (configuration.urlConf.contentType.equals(ContentTypes.`application/x-www-form-urlencoded`)) {
-          urlAuth -> HttpEntity(configuration.urlConf.contentType, ByteString(queryString))
+          url -> HttpEntity(configuration.urlConf.contentType, ByteString(queryString))
         } else {
           val querySeparator = authQueryParam match {
             case Some(_) => "&"
             case _ => "?"
           }
-          s"$urlAuth$querySeparator$queryString" -> HttpEntity.Empty
+          s"$url$querySeparator$queryString" -> HttpEntity.Empty
         }
-      case Some(JsonConf(json)) => urlAuth -> HttpEntity(ContentTypes.`application/json`, ByteString(json))
-      case _ => urlAuth -> HttpEntity.Empty
+      case Some(JsonConf(json)) => url -> HttpEntity(ContentTypes.`application/json`, ByteString(json))
+      case _ => url -> HttpEntity.Empty
     }
 
     HttpRequest(method = configuration.urlConf.method,
-      uri = finalUrl,
+      uri = cleanUrl(finalUrl),
       headers = authHeader,
       entity = httpBody)
   }

--- a/src/test/scala/com/getjenny/starchat/analyzer/atoms/http/HttpRequestAtomicTest.scala
+++ b/src/test/scala/com/getjenny/starchat/analyzer/atoms/http/HttpRequestAtomicTest.scala
@@ -339,27 +339,6 @@ class HttpRequestAtomicTest extends AnyWordSpec with Matchers with ScalatestRout
       validation shouldBe a[Success[_]]
     }
 
-    "create a valid http atom configuration with spaces in input-query-template" in {
-      val systemConf = SystemConfiguration
-        .createMapFromPath("starchat.atom-values")
-      val arguments = List("http-atom.test.url=www.google.it",
-        "http-atom.test.http-method=GET",
-        "http-atom.test.input-query-template",
-        "http-atom.test.output-content-type=test.content-type",
-        "http-atom.test.output-status=test.status",
-        "http-atom.test.output-data=test.data",
-        "http-atom.test.output-score=test.score"
-      )
-      val analyzerData = Map("http-atom.test.input-query-template" -> "aaa=b cd e")
-      val configuration = variableManager.validateAndBuild(arguments,systemConf, analyzerData, "")
-
-      configuration shouldBe a[Success[_]]
-      configuration.foreach { conf =>
-        val queryString = conf.inputConf.collect { case QueryStringConf(queryString) => queryString }.getOrElse("")
-        queryString shouldEqual "aaa=b+cd+e"
-      }
-    }
-
     /*"test weather api call and do not execute call if done before and actual call is 0" in {
       val description = "desc"
       val humidity = "1"

--- a/src/test/scala/com/getjenny/starchat/analyzer/atoms/http/HttpRequestAtomicTest.scala
+++ b/src/test/scala/com/getjenny/starchat/analyzer/atoms/http/HttpRequestAtomicTest.scala
@@ -575,6 +575,19 @@ class HttpRequestAtomicTest extends AnyWordSpec with Matchers with ScalatestRout
     }
      */
     /*
+    "test s3 atom with parameter containing non-ascii and space" in {
+
+      val systemConf = SystemConfiguration
+        .createMapFromPath("starchat.atom-values")
+
+      val atom = new HttpRequestAtomic(List("s3-folder-id=cloudpermit-towns","item-id=Pedersören kunta"), systemConf) with ReadS3DataVariableManager
+
+      val result = atom.evaluate("", AnalyzersDataInternal())
+      println(result)
+      result.data.extractedVariables.foreach(println)
+    }
+    */
+    /*
     "test ZendeskSearchTickets atom" in {
 
       val systemConf = SystemConfiguration


### PR DESCRIPTION
In http atom, before sending request, the url is modified in order to:
 * remove diacritics (e.g. ä -> a);
 * replace spaces by `+` symbol.