### PR TITLE
new entityExtractor atom

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -147,7 +147,7 @@ starchat {
         store-to = "header"
         key = "key"
         token = "supersecret"
-        input-json = """{"text": "<query>", "language": "<language>"}"""
+        input-json = """{"text": "<query>", "language": "<language>", "entity_types": ["<entity_type>"]}"""
       }
       readS3Data {
         url = "https://retrieve-data-atomic.s3.eu-west-1.amazonaws.com/<s3-folder-id>/<item-id>"

--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/EntityExtractorVariableManager.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/EntityExtractorVariableManager.scala
@@ -6,12 +6,14 @@ import com.getjenny.starchat.analyzer.atoms.http._
 import scalaz.Scalaz._
 import spray.json._
 
+
 /**
   * entityExtractor("language=it", "entity_type=LOC")
   *
   * Connects to the service entity-extractor (https://github.com/GetJenny/entity-extractor)
   * and extract defined entity
   *
+  * Supported entities are ATM: LOC, NAMES, CITY_FI
   * Query: "Milano e Roma non sono piccole"
   *
   * %extracted_entities.LOC.0% = "Milano"
@@ -32,22 +34,37 @@ case class EntityExtractorOutput(
                             override val score: String = "extracted_entities.score",
                             responseStatus: String = "extracted_entities.status",
                             location: String = "extracted_entities.LOC",
+                            firstName: String = "extracted_entities.NAMES",
+                            cityFi: String = "extracted_entities.CITY_FI",
                           ) extends HttpAtomOutputConf {
 
   override def bodyParser(body: String, contentType: String, status: StatusCode): Map[String, String] = {
     if(StatusCodes.OK.equals(status)){
       val json = body.parseJson.asJsObject
-      val locationList = json.fields.get("LOC").map {
-        case JsArray(locations) => locations.toArray.map(_.toString.stripPrefix("\"").stripSuffix("\""))
-        case _ => Array.empty[String]
-      }.getOrElse(Array.empty[String])
+      // map over json, match entity_tye with case (non-null), create a list of strings
+      val extractedEntitiesMap = json.fields.filter(x => x._2.toString() != "null")
 
-      val s = if(locationList.isEmpty) "0" else "1"
+      val s = if(extractedEntitiesMap.isEmpty) "0" else "1"
 
-      (locationList.indices.map(x => location + "." + x) zip locationList).toMap ++
+      val entityTypeAndList = extractedEntitiesMap.map {
+        case (entityType, JsArray(extractedEntities)) => (entityType, extractedEntities.toList.map(_.toString.stripPrefix("\"").stripSuffix("\"")))
+        case _ => List(List())
+      }.headOption.getOrElse(List())
+
+      def outputMap(extractedEntities: List[Any], typeEntity: String) =
+        extractedEntities.zipWithIndex.map(x => (typeEntity + "." + x._2, x._1.toString)).toMap
+
+      val entityType = entityTypeAndList match {
+        case ("LOC", head :: tail) => outputMap(head :: tail, location)
+        case ("NAMES", head :: tail) => outputMap(head :: tail, firstName)
+        case ("CITY_FI", head :: tail) => outputMap(head :: tail, cityFi)
+        case _ => outputMap(List(), location)
+      }
+
+      entityType ++
       Map(
         score -> s,
-        responseStatus -> status.toString
+        responseStatus -> status.toString,
       )
     } else {
       Map(

--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/EntityExtractorVariableManager.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/EntityExtractorVariableManager.scala
@@ -46,8 +46,8 @@ case class EntityExtractorOutput(
     if(StatusCodes.OK.equals(status)){
       val jsonFields = body.parseJson.asJsObject.fields
       val extractedEntitiesMap = jsonFields.filter(x => {
-        val jsonValueString = x._2.toString
-        jsonValueString =/= "null"
+        val jsonValue = x._2
+        jsonValue.toString =/= "null"
       })
 
 
@@ -61,8 +61,9 @@ case class EntityExtractorOutput(
 
       def outputMap(extractedEntities: List[Any], typeEntity: String): Map[String, String] = {
         val output = extractedEntities.zipWithIndex.map(x => {
-          val extractedEntityString = x._1.toString
-          (typeEntity + "." + x._2, extractedEntityString)
+          val extractedEntity = x._1
+          val entityNumber = x._2
+          (typeEntity + "." + entityNumber, extractedEntity.toString)
         })
         output.toMap
       }

--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/EntityExtractorVariableManager.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/EntityExtractorVariableManager.scala
@@ -45,18 +45,25 @@ case class EntityExtractorOutput(
 
     if(StatusCodes.OK.equals(status)){
       val jsonFields = body.parseJson.asJsObject.fields
-      val extractedEntitiesMap = jsonFields.filter(x => x._2.toString() =/= "null")
+      val extractedEntitiesMap = jsonFields.filter(x => {
+        val jsonValueString = x._2.toString
+        jsonValueString =/= "null"
+      })
 
 
       val s = if(extractedEntitiesMap.isEmpty) scoreNotExtracted else scoreExtracted
 
+      val quoteMark = "\""
       val entityTypeAndList = extractedEntitiesMap.map {
-        case (entityType, JsArray(extractedEntities)) => (entityType, extractedEntities.toList.map(_.toString.stripPrefix("\"").stripSuffix("\"")))
+        case (entityType, JsArray(extractedEntities)) => (entityType, extractedEntities.toList.map(_.toString.stripPrefix(quoteMark).stripSuffix(quoteMark)))
         case _ => List(List())
       }.headOption.getOrElse(List())
 
       def outputMap(extractedEntities: List[Any], typeEntity: String): Map[String, String] = {
-        val output = extractedEntities.zipWithIndex.map(x => (typeEntity + "." + x._2, x._1.toString))
+        val output = extractedEntities.zipWithIndex.map(x => {
+          val extractedEntityString = x._1.toString
+          (typeEntity + "." + x._2, extractedEntityString)
+        })
         output.toMap
       }
 

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -147,7 +147,7 @@ starchat {
         store-to = "header"
         key = "key"
         token = "supersecret"
-        input-json = """{"text": "<query>", "language": "<language>"}"""
+        input-json = """{"text": "<query>", "language": "<language>", "entity_types": ["<entity_type>"]}"""
       }
       readS3Data {
         url = "https://retrieve-data-atomic.s3.eu-west-1.amazonaws.com/<s3-folder-id>/<item-id>"

--- a/src/test/scala/com/getjenny/starchat/analyzer/atoms/http/HttpRequestAtomicTest.scala
+++ b/src/test/scala/com/getjenny/starchat/analyzer/atoms/http/HttpRequestAtomicTest.scala
@@ -2,7 +2,7 @@ package com.getjenny.starchat.analyzer.atoms.http
 
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.getjenny.analyzer.expressions.AnalyzersDataInternal
-import com.getjenny.starchat.analyzer.atoms.http.custom.{WeatherVariableManager, ZendeskSearchTicketsVariableManager, ZendeskTicketCommentsVariableManager}
+import com.getjenny.starchat.analyzer.atoms.http.custom.{EntityExtractorVariableManager, WeatherVariableManager, ZendeskSearchTicketsVariableManager, ZendeskTicketCommentsVariableManager}
 import com.getjenny.starchat.utils.SystemConfiguration
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -528,18 +528,161 @@ class HttpRequestAtomicTest extends AnyWordSpec with Matchers with ScalatestRout
      */
 
     /*
-    "test entityExtractor" in {
-
+    "test entityExtractor entity_type LOC, italian, single entity" in {
       val systemConf = SystemConfiguration
-        .createMapFromPath("starchat.entity-extractor")
+        .createMapFromPath("starchat.atom-values")
+      val atom = new HttpRequestAtomic(List("language=it", "entity_type=LOC"), systemConf) with EntityExtractorVariableManager
+      val result = atom.evaluate("Milano è una grande città", AnalyzersDataInternal())
 
-      val atom = new HttpRequestAtomic(List("language=it"), systemConf) with EntityExtractorVariableManager
+      result.data.extractedVariables.getOrElse("extracted_entities.score", "") shouldBe "1"
+      result.data.extractedVariables.getOrElse("extracted_entities.status", "") shouldBe "200 OK"
+      result.data.extractedVariables.getOrElse("extracted_entities.LOC.0", "") shouldBe "Milano"
+    }
 
+    "test entityExtractor entity_type LOC, italian, multiple entities" in {
+      val systemConf = SystemConfiguration
+        .createMapFromPath("starchat.atom-values")
+      val atom = new HttpRequestAtomic(List("language=it", "entity_type=LOC"), systemConf) with EntityExtractorVariableManager
       val result = atom.evaluate("Milano e Roma son grandi città", AnalyzersDataInternal())
-      println(result)
 
+      result.data.extractedVariables.getOrElse("extracted_entities.score", "") shouldBe "1"
+      result.data.extractedVariables.getOrElse("extracted_entities.status", "") shouldBe "200 OK"
+      result.data.extractedVariables.getOrElse("extracted_entities.LOC.0", "") shouldBe "Milano"
+      result.data.extractedVariables.getOrElse("extracted_entities.LOC.1", "") shouldBe "Roma"
+    }
+
+    "test entityExtractor entity_type LOC, italian, no entities" in {
+      val systemConf = SystemConfiguration
+        .createMapFromPath("starchat.atom-values")
+      val atom = new HttpRequestAtomic(List("language=it", "entity_type=LOC"), systemConf) with EntityExtractorVariableManager
+      val result = atom.evaluate("I like ice cream.", AnalyzersDataInternal())
+
+      result.data.extractedVariables.getOrElse("extracted_entities.score", "") shouldBe "0"
+      result.data.extractedVariables.getOrElse("extracted_entities.status", "") shouldBe "200 OK"
+    }
+
+    "test entityExtractor entity_type LOC, finnish, single entity" in {
+      val systemConf = SystemConfiguration
+        .createMapFromPath("starchat.atom-values")
+      val atom = new HttpRequestAtomic(List("language=fi", "entity_type=LOC"), systemConf) with EntityExtractorVariableManager
+      val result = atom.evaluate("Helsinki on kaunis kaupunki", AnalyzersDataInternal())
+
+      result.data.extractedVariables.getOrElse("extracted_entities.score", "") shouldBe "1"
+      result.data.extractedVariables.getOrElse("extracted_entities.status", "") shouldBe "200 OK"
+      result.data.extractedVariables.getOrElse("extracted_entities.LOC.0", "") shouldBe "Helsinki"
+    }
+
+    "test entityExtractor entity_type LOC, finnish, multiple entities" in {
+      val systemConf = SystemConfiguration
+        .createMapFromPath("starchat.atom-values")
+      val atom = new HttpRequestAtomic(List("language=fi", "entity_type=LOC"), systemConf) with EntityExtractorVariableManager
+      val result = atom.evaluate("Rooma ja Helsinki ovat pääkaupunkeja", AnalyzersDataInternal())
+
+      result.data.extractedVariables.getOrElse("extracted_entities.score", "") shouldBe "1"
+      result.data.extractedVariables.getOrElse("extracted_entities.status", "") shouldBe "200 OK"
+      result.data.extractedVariables.getOrElse("extracted_entities.LOC.0", "") shouldBe "Rooma"
+      result.data.extractedVariables.getOrElse("extracted_entities.LOC.1", "") shouldBe "Helsinki"
+    }
+
+    "test entityExtractor entity_type LOC, finnish, no entities" in {
+      val systemConf = SystemConfiguration
+        .createMapFromPath("starchat.atom-values")
+      val atom = new HttpRequestAtomic(List("language=fi", "entity_type=LOC"), systemConf) with EntityExtractorVariableManager
+      val result = atom.evaluate("I like ice cream.", AnalyzersDataInternal())
+
+      result.data.extractedVariables.getOrElse("extracted_entities.score", "") shouldBe "0"
+      result.data.extractedVariables.getOrElse("extracted_entities.status", "") shouldBe "200 OK"
+    }
+
+    "test entityExtractor entity_type NAMES, single entity" in {
+      val systemConf = SystemConfiguration
+        .createMapFromPath("starchat.atom-values")
+      val atom = new HttpRequestAtomic(List("language=en", "entity_type=NAMES"), systemConf) with EntityExtractorVariableManager
+      val result = atom.evaluate("Alberto likes ice cream.", AnalyzersDataInternal())
+
+      result.data.extractedVariables.getOrElse("extracted_entities.score", "") shouldBe "1"
+      result.data.extractedVariables.getOrElse("extracted_entities.status", "") shouldBe "200 OK"
+      result.data.extractedVariables.getOrElse("extracted_entities.NAMES.0", "") shouldBe "Alberto"
+    }
+
+    "test entityExtractor entity_type NAMES, non-ascii" in {
+      val systemConf = SystemConfiguration
+        .createMapFromPath("starchat.atom-values")
+      val atom = new HttpRequestAtomic(List("language=en", "entity_type=NAMES"), systemConf) with EntityExtractorVariableManager
+      val result = atom.evaluate("Álvaro likes ice cream.", AnalyzersDataInternal())
+
+      result.data.extractedVariables.getOrElse("extracted_entities.score", "") shouldBe "1"
+      result.data.extractedVariables.getOrElse("extracted_entities.status", "") shouldBe "200 OK"
+      result.data.extractedVariables.getOrElse("extracted_entities.NAMES.0", "") shouldBe "Álvaro"
+    }
+
+    "test entityExtractor entity_type NAMES, multiple entities" in {
+      val systemConf = SystemConfiguration
+        .createMapFromPath("starchat.atom-values")
+      val atom = new HttpRequestAtomic(List("language=en", "entity_type=NAMES"), systemConf) with EntityExtractorVariableManager
+      val result = atom.evaluate("Vladimiro and Riccarda like ice cream.", AnalyzersDataInternal())
+
+      result.data.extractedVariables.getOrElse("extracted_entities.score", "") shouldBe "1"
+      result.data.extractedVariables.getOrElse("extracted_entities.status", "") shouldBe "200 OK"
+      result.data.extractedVariables.getOrElse("extracted_entities.NAMES.0", "") shouldBe "Vladimiro"
+      result.data.extractedVariables.getOrElse("extracted_entities.NAMES.1", "") shouldBe "Riccarda"
+    }
+
+    "test entityExtractor entity_type NAMES, no entities" in {
+      val systemConf = SystemConfiguration
+        .createMapFromPath("starchat.atom-values")
+      val atom = new HttpRequestAtomic(List("language=en", "entity_type=LOC"), systemConf) with EntityExtractorVariableManager
+      val result = atom.evaluate("I like ice cream.", AnalyzersDataInternal())
+
+      result.data.extractedVariables.getOrElse("extracted_entities.score", "") shouldBe "0"
+      result.data.extractedVariables.getOrElse("extracted_entities.status", "") shouldBe "200 OK"
+    }
+
+    "test entityExtractor entity_type CITY_FI, single entity" in {
+      val systemConf = SystemConfiguration
+        .createMapFromPath("starchat.atom-values")
+      val atom = new HttpRequestAtomic(List("language=en", "entity_type=CITY_FI"), systemConf) with EntityExtractorVariableManager
+      val result = atom.evaluate("I will travel to Tampere.", AnalyzersDataInternal())
+
+      result.data.extractedVariables.getOrElse("extracted_entities.score", "") shouldBe "1"
+      result.data.extractedVariables.getOrElse("extracted_entities.status", "") shouldBe "200 OK"
+      result.data.extractedVariables.getOrElse("extracted_entities.CITY_FI.0", "") shouldBe "Tampere"
+    }
+
+    "test entityExtractor entity_type CITY_FI, multiple entities" in {
+      val systemConf = SystemConfiguration
+        .createMapFromPath("starchat.atom-values")
+      val atom = new HttpRequestAtomic(List("language=en", "entity_type=CITY_FI"), systemConf) with EntityExtractorVariableManager
+      val result = atom.evaluate("I will travel from Kuopio to Mikkeli.", AnalyzersDataInternal())
+
+      result.data.extractedVariables.getOrElse("extracted_entities.score", "") shouldBe "1"
+      result.data.extractedVariables.getOrElse("extracted_entities.status", "") shouldBe "200 OK"
+      result.data.extractedVariables.getOrElse("extracted_entities.CITY_FI.0", "") shouldBe "Kuopio"
+      result.data.extractedVariables.getOrElse("extracted_entities.CITY_FI.1", "") shouldBe "Mikkeli"
+    }
+
+    "test entityExtractor entity_type CITY_FI, non-ascii" in {
+      val systemConf = SystemConfiguration
+        .createMapFromPath("starchat.atom-values")
+      val atom = new HttpRequestAtomic(List("language=en", "entity_type=CITY_FI"), systemConf) with EntityExtractorVariableManager
+      val result = atom.evaluate("I will travel to Jyväskylä.", AnalyzersDataInternal())
+
+      result.data.extractedVariables.getOrElse("extracted_entities.score", "") shouldBe "1"
+      result.data.extractedVariables.getOrElse("extracted_entities.status", "") shouldBe "200 OK"
+      result.data.extractedVariables.getOrElse("extracted_entities.CITY_FI.0", "") shouldBe "Jyväskylä"
+    }
+
+    "test entityExtractor entity_type CITY_FI, no entities" in {
+      val systemConf = SystemConfiguration
+        .createMapFromPath("starchat.atom-values")
+      val atom = new HttpRequestAtomic(List("language=en", "entity_type=LOC"), systemConf) with EntityExtractorVariableManager
+      val result = atom.evaluate("I like ice cream.", AnalyzersDataInternal())
+
+      result.data.extractedVariables.getOrElse("extracted_entities.score", "") shouldBe "0"
+      result.data.extractedVariables.getOrElse("extracted_entities.status", "") shouldBe "200 OK"
     }
     */
+
     /*
     "test s3 atom" in {
 


### PR DESCRIPTION
Modify entityExtractor atomic so that accepts an argument entity_type with a single descriptor:

```
query: "helsinki"
entityExtractor(entityTypes="CITY_FI") returns score 1
entityExtractor(entityTypes="NAMES") returns score 0
entityExtractor() error
```