### PR TITLE
Add CITY_FI support in entityExtractor atom

### DIFF
--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/EntityExtractorVariableManager.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/EntityExtractorVariableManager.scala
@@ -19,6 +19,10 @@ import spray.json._
   * %extracted_entities.LOC.0% = "Milano"
   * %extracted_entities.LOC.1% = "Roma"
   *
+  * To add entities, add the proper label (matching with entity-extractor) in:
+  *  - `EntityExtractorOutput` arguments,
+  *  - `EntityExtractorOutput.bodyParser.entities` list,
+  *  - additional case in `EntityExtractorOutput.bodyParser.entityType` match statement.
   */
 
 trait EntityExtractorVariableManager extends GenericVariableManager {

--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/EntityExtractorVariableManager.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/EntityExtractorVariableManager.scala
@@ -47,7 +47,11 @@ case class EntityExtractorOutput(
     val scoreExtracted = "1"
     val scoreNotExtracted = "0"
 
-    val entities = List("LOC", "NAMES", "CITY_FI")
+    val labelLoc = "LOC"
+    val labelNames = "NAMES"
+    val labelCityFi = "CITY_FI"
+
+    val entities = List(labelLoc, labelNames, labelCityFi)
 
     if(StatusCodes.OK.equals(status)){
       val jsonFields = body.parseJson.asJsObject.fields
@@ -66,18 +70,18 @@ case class EntityExtractorOutput(
       }.headOption.getOrElse(List())
 
       def outputMap(extractedEntities: List[Any], typeEntity: String): Map[String, String] = {
-        val output = extractedEntities.zipWithIndex.map(x => {
-          val extractedEntity = x._1
-          val entityNumber = x._2
+        val output = extractedEntities.zipWithIndex.map(extractedEntityWithIndex => {
+          val extractedEntity = extractedEntityWithIndex._1
+          val entityNumber = extractedEntityWithIndex._2
           (typeEntity + "." + entityNumber, extractedEntity.toString)
         })
         output.toMap
       }
 
       val entityType = entityTypeAndList match {
-        case ("LOC", head :: tail) => outputMap(head :: tail, location)
-        case ("NAMES", head :: tail) => outputMap(head :: tail, firstName)
-        case ("CITY_FI", head :: tail) => outputMap(head :: tail, cityFi)
+        case (`labelLoc`, head :: tail) => outputMap(head :: tail, location)
+        case (`labelNames`, head :: tail) => outputMap(head :: tail, firstName)
+        case (`labelCityFi`, head :: tail) => outputMap(head :: tail, cityFi)
         case _ => outputMap(List(), location)
       }
 

--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/EntityExtractorVariableManager.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/EntityExtractorVariableManager.scala
@@ -55,11 +55,9 @@ case class EntityExtractorOutput(
 
     if(StatusCodes.OK.equals(status)){
       val jsonFields = body.parseJson.asJsObject.fields
-      val extractedEntitiesMap = jsonFields.filter(x => {
-        val entity = x._1
-        val jsonValue = x._2
-        (jsonValue.toString =/= "null") & entities.contains(entity)
-      })
+      val extractedEntitiesMap = jsonFields.filter{
+        case (entity, value) => (value.toString =/= "null") & entities.contains(entity)
+      }
 
       val s = if(extractedEntitiesMap.isEmpty) scoreNotExtracted else scoreExtracted
 
@@ -70,11 +68,7 @@ case class EntityExtractorOutput(
       }.headOption.getOrElse(List())
 
       def outputMap(extractedEntities: List[Any], typeEntity: String): Map[String, String] = {
-        val output = extractedEntities.zipWithIndex.map(extractedEntityWithIndex => {
-          val extractedEntity = extractedEntityWithIndex._1
-          val entityNumber = extractedEntityWithIndex._2
-          (typeEntity + "." + entityNumber, extractedEntity.toString)
-        })
+        val output = extractedEntities.zipWithIndex.map{ case (item, i) => Tuple2(typeEntity + "." + i, item.toString)}
         output.toMap
       }
 

--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/EntityExtractorVariableManager.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/EntityExtractorVariableManager.scala
@@ -43,13 +43,15 @@ case class EntityExtractorOutput(
     val scoreExtracted = "1"
     val scoreNotExtracted = "0"
 
+    val entities = List("LOC", "NAMES", "CITY_FI")
+
     if(StatusCodes.OK.equals(status)){
       val jsonFields = body.parseJson.asJsObject.fields
       val extractedEntitiesMap = jsonFields.filter(x => {
+        val entity = x._1
         val jsonValue = x._2
-        jsonValue.toString =/= "null"
+        (jsonValue.toString =/= "null") & entities.contains(entity)
       })
-
 
       val s = if(extractedEntitiesMap.isEmpty) scoreNotExtracted else scoreExtracted
 


### PR DESCRIPTION
The atom `entityExtractor` supports now the following entities: LOC, NAMES, CITY_FI.