### PR TITLE
GJ 2372 - Modify output score in zendeskSearchTickets atom

### DIFF
--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/ZendeskSearchTicketsVariableManager.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/ZendeskSearchTicketsVariableManager.scala
@@ -30,21 +30,21 @@ trait ZendeskSearchTicketsVariableManager extends GenericVariableManager {
   val factoryName = s"zendeskSearchTickets"
   override def outputConf(configuration: VariableConfiguration, findProperty: String => Option[String]):
                AtomValidation[HttpAtomOutputConf] = {
-    val userEmail = findProperty("user-email")
-      .toSuccessNel("user-email not found, unable to create output conf")
-    userEmail.map(_ => ZendeskOutput(prefix = factoryName, score = factoryName + ".score"))
+    ZendeskOutput().successNel
   }
 }
 
-case class ZendeskOutput(prefix: String,
-                    override val score: String,
-                   ) extends HttpAtomOutputConf {
+case class ZendeskOutput(
+                          override val score: String = "zendeskSearchTickets.score",
+                          zendeskSearchTicketsStatus: String = "zendeskSearchTickets.status",
+                          numberOfTickets: String = "zendeskSearchTickets.count",
+                          ticketsIdAndSubject: String = "zendeskSearchTickets.tickets",
+                        ) extends HttpAtomOutputConf {
 
   override def bodyParser(body: String, contentType: String, status: StatusCode): Map[String, String] = {
 
     val scoreExtracted = "1"
     val scoreNotExtracted = "0"
-    val labelOutputStatus = s"$prefix.status"
 
     if(StatusCodes.OK.value === status.value){
       val json = body.parseJson.asJsObject
@@ -63,21 +63,21 @@ case class ZendeskOutput(prefix: String,
       if (equiv(count.toInt, 0)) {
         Map(
           score -> scoreNotExtracted,
-          labelOutputStatus -> status.toString
+          zendeskSearchTicketsStatus -> status.toString
         )
       } else {
         Map(
           score -> scoreExtracted,
-          labelOutputStatus -> status.toString,
-          s"$prefix.count" -> count,
-          s"$prefix.tickets" -> ticketDetails
+          zendeskSearchTicketsStatus -> status.toString,
+          numberOfTickets -> count,
+          ticketsIdAndSubject -> ticketDetails
         )
       }
 
     } else {
       Map(
         score -> scoreNotExtracted,
-        labelOutputStatus -> status.toString
+        zendeskSearchTicketsStatus -> status.toString
       )
     }
   }

--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/ZendeskTicketCommentsVariableManager.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/ZendeskTicketCommentsVariableManager.scala
@@ -13,7 +13,7 @@ trait ZendeskTicketCommentsVariableManager extends GenericVariableManager {
   *
   * ticket-id:   14
   *
-  * zendeskSearchTicketComments("ticket-id=14")
+  * zendeskTicketComments("ticket-id=14")
   *
   * Variables set:
   *
@@ -57,7 +57,7 @@ case class TicketCommentsOutput(prefix: String,
         s"${values._1} (${values._2})"
       }.mkString("; ")
 
-      val count = json.fields.get("count").toString  // there should be always at least 1 comment (the creation)
+      val count = json.fields.getOrElse("count", 0).toString  // there should be always at least 1 comment (the creation)
 
       Map(
         score -> "1",

--- a/src/test/scala/com/getjenny/starchat/analyzer/atoms/http/HttpRequestAtomicTest.scala
+++ b/src/test/scala/com/getjenny/starchat/analyzer/atoms/http/HttpRequestAtomicTest.scala
@@ -723,7 +723,7 @@ class HttpRequestAtomicTest extends AnyWordSpec with Matchers with ScalatestRout
       result.data.extractedVariables.foreach(println)
     }
   */
-    /*
+
     "create a valid zendesk atom configuration" in {
       val variableManager = new ZendeskSearchTicketsVariableManager {}
       val systemConf = SystemConfiguration
@@ -732,7 +732,7 @@ class HttpRequestAtomicTest extends AnyWordSpec with Matchers with ScalatestRout
         configuration shouldBe a[Success[_]]
         configuration.map(println)
     }
-  */
+
     /*
   "test ZendeskTicketComments atom" in {
 


### PR DESCRIPTION
If there are no tickets on Zendesk associated to the given email, the output score of the atom is zero. See GJ-2372 for more details.