### PR TITLE
GJ 2404 - zendeskTicketComments: add possibility to retrieve only public comments

### DIFF
--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/ZendeskTicketCommentsVariableManager.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/ZendeskTicketCommentsVariableManager.scala
@@ -1,7 +1,7 @@
 package com.getjenny.starchat.analyzer.atoms.http.custom
 
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
-import com.getjenny.starchat.analyzer.atoms.http.AtomVariableReader.{VariableConfiguration, keyFromMap}
+import com.getjenny.starchat.analyzer.atoms.http.AtomVariableReader._
 import com.getjenny.starchat.analyzer.atoms.http._
 import scalaz.Scalaz._
 import scalaz.Success
@@ -37,7 +37,7 @@ trait ZendeskTicketCommentsVariableManager extends ZendeskVariableManager {
   val factoryName = s"zendeskTicketComments"
   override def outputConf(configuration: VariableConfiguration, findProperty: String => Option[String]):
                AtomValidation[HttpAtomOutputConf] = {
-    keyFromMap(configuration, "include-private") match {
+    as[String]("include-private").run(configuration) match {
       case Success("false") =>  TicketCommentsOutput(includePrivate = false).successNel
       case _ => TicketCommentsOutput(includePrivate = true).successNel  // if not specified, private comments are included
     }

--- a/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/ZendeskTicketCommentsVariableManager.scala
+++ b/src/main/scala/com/getjenny/starchat/analyzer/atoms/http/custom/ZendeskTicketCommentsVariableManager.scala
@@ -64,7 +64,7 @@ case class TicketCommentsOutput(
       val commentDetails = comments
         .toList.filter{  // filter out private comments if includePrivate set to false
         if (includePrivate) (_: JsValue) => true
-        else (x: JsValue) => x.asJsObject.getFields("public").head.toString == "true"
+        else (x: JsValue) => x.asJsObject.getFields("public")(0).toString === "true"
       }
         .map( x => x.asJsObject.getFields("plain_body", "created_at"))
         .zipWithIndex


### PR DESCRIPTION
Changes: 
1. Add optional argument `include-private` to `zendeskTicketComments` atom. If the argument is set to false, private comments are filtered out and only public comments are retrieved. If `include-private` is not specified or set to true, both public and private comments are returned.

2. Modify variable `zendeskTicketComments.comments` so that the output string has a nicer format (see GJ-2406)